### PR TITLE
Changes to match rfc7233 (#49)

### DIFF
--- a/baize/asgi/websocket.py
+++ b/baize/asgi/websocket.py
@@ -8,8 +8,9 @@ from .responses import Response
 
 
 class WebSocketDisconnect(Exception):
-    def __init__(self, code: int = 1000) -> None:
+    def __init__(self, code: int = 1000, reason: str = "") -> None:
         self.code = code
+        self.reason = reason
 
 
 class WebSocketState(enum.Enum):

--- a/baize/responses.py
+++ b/baize/responses.py
@@ -178,10 +178,12 @@ class FileResponseMixin:
             raise MalformedRangeHeader("Only support bytes range")
 
         ranges = [
-            (int(_[0]) if _[0] else max_size-int(_[1]),
-             int(_[1]) + 1 if _[0] and _[1] and int(_[1]) < max_size else max_size)
+            (
+                int(_[0]) if _[0] else max_size - int(_[1]),
+                int(_[1]) + 1 if _[0] and _[1] and int(_[1]) < max_size else max_size,
+            )
             for _ in re.findall(r"(\d*)-(\d*)", ranges_str)
-         ]
+        ]
 
         if any(start > max_size for start, _ in ranges):
             raise RangeNotSatisfiable(max_size)

--- a/baize/responses.py
+++ b/baize/responses.py
@@ -178,15 +178,16 @@ class FileResponseMixin:
             raise MalformedRangeHeader("Only support bytes range")
 
         ranges = [
-            (int(_[0]), int(_[1]) + 1 if _[1] else max_size)
-            for _ in re.findall(r"(\d+)-(\d*)", ranges_str)
-        ]
+            (int(_[0]) if _[0] else max_size-int(_[1]),
+             int(_[1]) + 1 if _[0] and _[1] and int(_[1]) < max_size else max_size)
+            for _ in re.findall(r"(\d*)-(\d*)", ranges_str)
+         ]
+
+        if any(start > max_size for start, _ in ranges):
+            raise RangeNotSatisfiable(max_size)
 
         if any(start > end for start, end in ranges):
             raise MalformedRangeHeader("Range header: start must be less than end")
-
-        if any(end > max_size for _, end in ranges):
-            raise RangeNotSatisfiable(max_size)
 
         if len(ranges) == 1:
             return ranges

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -19,6 +19,10 @@ def test_base_file_response_parse_range(tmp_path: Path):
         (20, 30),
         (40, 4623),
     ] == response.parse_range("bytes=0-10, 50-, 20-29, 40-50, 20-29", 4623)
+    assert response.parse_range("bytes=0-54321",4623) == [(0,4623)]
+    assert response.parse_range("bytes=-500",4623) == [(4123,4623)]
+    assert response.parse_range("bytes=20-29, -500",4623) == [(20,30),(4123,4623)]
+    assert response.parse_range("bytes=4100-4200, -500",4623) == [(4100,4623)]
 
     with pytest.raises(MalformedRangeHeader):
         response.parse_range("byte=0-10", 4623)
@@ -27,4 +31,11 @@ def test_base_file_response_parse_range(tmp_path: Path):
         response.parse_range("bytes=10-0", 4623)
 
     with pytest.raises(RangeNotSatisfiable):
-        response.parse_range("bytes=0-4623", 4623)
+        response.parse_range("bytes=4625-4635", 4623)
+
+    with pytest.raises(RangeNotSatisfiable):
+        response.parse_range("bytes=0-10, 4625-4635", 4623)
+
+    with pytest.raises(RangeNotSatisfiable):
+        response.parse_range("bytes=8000-", 4623)
+

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -19,10 +19,10 @@ def test_base_file_response_parse_range(tmp_path: Path):
         (20, 30),
         (40, 4623),
     ] == response.parse_range("bytes=0-10, 50-, 20-29, 40-50, 20-29", 4623)
-    assert response.parse_range("bytes=0-54321",4623) == [(0,4623)]
-    assert response.parse_range("bytes=-500",4623) == [(4123,4623)]
-    assert response.parse_range("bytes=20-29, -500",4623) == [(20,30),(4123,4623)]
-    assert response.parse_range("bytes=4100-4200, -500",4623) == [(4100,4623)]
+    assert response.parse_range("bytes=0-54321", 4623) == [(0, 4623)]
+    assert response.parse_range("bytes=-500", 4623) == [(4123, 4623)]
+    assert response.parse_range("bytes=20-29, -500", 4623) == [(20, 30), (4123, 4623)]
+    assert response.parse_range("bytes=4100-4200, -500", 4623) == [(4100, 4623)]
 
     with pytest.raises(MalformedRangeHeader):
         response.parse_range("byte=0-10", 4623)
@@ -38,4 +38,3 @@ def test_base_file_response_parse_range(tmp_path: Path):
 
     with pytest.raises(RangeNotSatisfiable):
         response.parse_range("bytes=8000-", 4623)
-

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -366,8 +366,8 @@ def test_file_response(tmp_path: Path):
         )
         assert response.status_code == 206
 
-        response = client.head("/", headers={"Range": "bytes=0-1000"})
-        assert response.status_code == 206
+        response = client.head("/", headers={"Range": "bytes:0-1000"})
+        assert response.status_code == 400
 
         response = client.head(
             "/", headers={"Range": f"bytes={len(README.encode('utf8'))+1}-{len(README.encode('utf8'))+12}"}

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -366,11 +366,11 @@ def test_file_response(tmp_path: Path):
         )
         assert response.status_code == 206
 
-        response = client.head("/", headers={"Range": "bytes: 0-1000"})
-        assert response.status_code == 400
+        response = client.head("/", headers={"Range": "bytes=0-1000"})
+        assert response.status_code == 206
 
         response = client.head(
-            "/", headers={"Range": f"bytes=0-{len(README.encode('utf8'))+1}"}
+            "/", headers={"Range": f"bytes={len(README.encode('utf8'))+1}-{len(README.encode('utf8'))+12}"}
         )
         assert response.status_code == 416
         assert response.headers["Content-Range"] == f"*/{len(README.encode('utf8'))}"

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -366,11 +366,14 @@ def test_file_response(tmp_path: Path):
         )
         assert response.status_code == 206
 
-        response = client.head("/", headers={"Range": "bytes:0-1000"})
+        response = client.head("/", headers={"Range": "bytes: 0-1000"})
         assert response.status_code == 400
 
         response = client.head(
-            "/", headers={"Range": f"bytes={len(README.encode('utf8'))+1}-{len(README.encode('utf8'))+12}"}
+            "/",
+            headers={
+                "Range": f"bytes={len(README.encode('utf8'))+1}-{len(README.encode('utf8'))+12}"
+            },
         )
         assert response.status_code == 416
         assert response.headers["Content-Range"] == f"*/{len(README.encode('utf8'))}"


### PR DESCRIPTION
## Changes Made

### feat: Added Range: Tests

Tests to evaluate
- ranges exceeding file size
- negative ranges (individually, as group, overlapping)
- RangeNotSatisfiable on range start > file size (individual, and as a group, and without a range end)

### fix: ranges logic update

The ranges calculation in parse_range now will return values for prefix, suffix, and over-large ranges. The rest of the logic should work with the change.

### fix: response tests pass

Final changes made to guarantee automated tests passed

## Tests 

All automated tests passed except `test_rejected_connection` but I don't think my changes touch that logic. I am willing to look over it if it's a concern.

Co-authored-by: Jason Schlesinger <cf21c001@meiji.ac.jp>