### PR TITLE
Changes to match rfc7233

### DIFF
--- a/baize/asgi/websocket.py
+++ b/baize/asgi/websocket.py
@@ -8,8 +8,9 @@ from .responses import Response
 
 
 class WebSocketDisconnect(Exception):
-    def __init__(self, code: int = 1000) -> None:
+    def __init__(self, code: int = 1000, reason: str = "") -> None:
         self.code = code
+        self.reason = reason
 
 
 class WebSocketState(enum.Enum):

--- a/baize/asgi/websocket.py
+++ b/baize/asgi/websocket.py
@@ -8,9 +8,8 @@ from .responses import Response
 
 
 class WebSocketDisconnect(Exception):
-    def __init__(self, code: int = 1000, reason: str = "") -> None:
+    def __init__(self, code: int = 1000) -> None:
         self.code = code
-        self.reason = reason
 
 
 class WebSocketState(enum.Enum):

--- a/baize/responses.py
+++ b/baize/responses.py
@@ -183,7 +183,11 @@ class FileResponseMixin:
                 int(_[1]) + 1 if _[0] and _[1] and int(_[1]) < max_size else max_size,
             )
             for _ in re.findall(r"(\d*)-(\d*)", ranges_str)
+            if _ != ("", "")
         ]
+
+        if len(ranges) == 0:
+            raise MalformedRangeHeader("Range header: range must be requested")
 
         if any(not (0 <= start < max_size) for start, _ in ranges):
             raise RangeNotSatisfiable(max_size)

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -878,7 +878,8 @@ def test_rejected_connection():
 
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect) as exc:
-        client.websocket_connect("/")
+        with client.websocket_connect("/") as websocket:
+            pass
     assert exc.value.code == 1001
 
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -883,8 +883,7 @@ def test_rejected_connection():
 
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect) as exc:
-        with client.websocket_connect("/"):
-            pass
+        client.websocket_connect("/")
     assert exc.value.code == 1001
 
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -883,7 +883,7 @@ def test_rejected_connection():
 
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect) as exc:
-        with client.websocket_connect("/") as _:
+        with client.websocket_connect("/"):
             pass
     assert exc.value.code == 1001
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -641,6 +641,11 @@ async def test_file_response(tmp_path: Path, response_class: Type[FileResponse])
         response = await client.head(
             "/", headers={"Range": f"bytes=0-{len(README.encode('utf8'))+1}"}
         )
+        assert response.status_code == 206
+
+        response = await client.head(
+            "/", headers={"Range": f"bytes={len(README.encode('utf8'))+1}-"}
+        )
         assert response.status_code == 416
         assert response.headers["Content-Range"] == f"*/{len(README.encode('utf8'))}"
 
@@ -878,7 +883,7 @@ def test_rejected_connection():
 
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect) as exc:
-        with client.websocket_connect("/") as websocket:
+        with client.websocket_connect("/") as _:
             pass
     assert exc.value.code == 1001
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -11,6 +11,8 @@ def test_base_file_response_parse_range(tmp_path: Path):
     response = FileResponseMixin
 
     assert response.parse_range("bytes=0-10", 4623) == [(0, 11)]
+    assert response.parse_range("bytes=0-10,hello", 4623) == [(0, 11)]
+    assert response.parse_range("bytes=0-10,-", 4623) == [(0, 11)]
     assert response.parse_range("bytes=0-10, 11-20", 4623) == [(0, 21)]
     assert response.parse_range("bytes=0-", 4623) == [(0, 4623)]
     assert response.parse_range("bytes=0-10, 5-", 4623) == [(0, 4623)]
@@ -23,6 +25,12 @@ def test_base_file_response_parse_range(tmp_path: Path):
     assert response.parse_range("bytes=-500", 4623) == [(4123, 4623)]
     assert response.parse_range("bytes=20-29, -500", 4623) == [(20, 30), (4123, 4623)]
     assert response.parse_range("bytes=4100-4200, -500", 4623) == [(4100, 4623)]
+
+    with pytest.raises(MalformedRangeHeader):
+        response.parse_range("bytes=-", 4623)
+
+    with pytest.raises(MalformedRangeHeader):
+        response.parse_range("bytes=", 4623)
 
     with pytest.raises(MalformedRangeHeader):
         response.parse_range("byte=0-10", 4623)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -19,6 +19,10 @@ def test_base_file_response_parse_range(tmp_path: Path):
         (20, 30),
         (40, 4623),
     ] == response.parse_range("bytes=0-10, 50-, 20-29, 40-50, 20-29", 4623)
+    assert response.parse_range("bytes=0-54321", 4623) == [(0, 4623)]
+    assert response.parse_range("bytes=-500", 4623) == [(4123, 4623)]
+    assert response.parse_range("bytes=20-29, -500", 4623) == [(20, 30), (4123, 4623)]
+    assert response.parse_range("bytes=4100-4200, -500", 4623) == [(4100, 4623)]
 
     with pytest.raises(MalformedRangeHeader):
         response.parse_range("byte=0-10", 4623)
@@ -27,4 +31,13 @@ def test_base_file_response_parse_range(tmp_path: Path):
         response.parse_range("bytes=10-0", 4623)
 
     with pytest.raises(RangeNotSatisfiable):
-        response.parse_range("bytes=0-4623", 4623)
+        response.parse_range("bytes=4625-4635", 4623)
+
+    with pytest.raises(RangeNotSatisfiable):
+        response.parse_range("bytes=0-10, 4625-4635", 4623)
+
+    with pytest.raises(RangeNotSatisfiable):
+        response.parse_range("bytes=8000-", 4623)
+
+    with pytest.raises(RangeNotSatisfiable):
+        response.parse_range("bytes=-9999", 4623)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -370,7 +370,10 @@ def test_file_response(tmp_path: Path):
         assert response.status_code == 400
 
         response = client.head(
-            "/", headers={"Range": f"bytes=0-{len(README.encode('utf8'))+1}"}
+            "/",
+            headers={
+                "Range": f"bytes={len(README.encode('utf8'))+1}-{len(README.encode('utf8'))+12}"
+            },
         )
         assert response.status_code == 416
         assert response.headers["Content-Range"] == f"*/{len(README.encode('utf8'))}"


### PR DESCRIPTION
Addresses issue #49 - adjustment of range headers.

* feat: Added Range: Tests

Tests to evaluate
- ranges exceeding file size
- negative ranges (individually, as group, overlapping)
- RangeNotSatisfiable on range start > file size (individual, and as a group, and without a range end)
- RangeNotSatisfiable on range start < 0 (when suffix > file size)

* fix: ranges logic update

The ranges calculation in parse_range now will return values for prefix, suffix, and over-large ranges.
The rest of the logic should work with the change.

* fix: response tests pass
- Other response tests modified to match expected functionality.
- Some minor changes to websockets to allow those tests to pass as well.