### PR TITLE
Fix tests failing with `httpx>=0.28`

### DIFF
--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import tempfile
 from functools import partial
 from inspect import cleandoc
@@ -152,7 +153,8 @@ async def test_request_body():
         assert response.json() == {"body": ""}
 
         response = await client.post("/", json={"a": "123"})
-        assert response.json() == {"body": '{"a": "123"}'}
+        inner_json = json.loads(response.json()["body"])
+        assert inner_json == {"a": "123"}
 
         response = await client.post("/", content="abc")
         assert response.json() == {"body": "abc"}
@@ -173,7 +175,8 @@ async def test_request_stream():
         assert response.json() == {"body": ""}
 
         response = await client.post("/", json={"a": "123"})
-        assert response.json() == {"body": '{"a": "123"}'}
+        inner_json = json.loads(response.json()["body"])
+        assert inner_json == {"a": "123"}
 
         response = await client.post("/", content="abc")
         assert response.json() == {"body": "abc"}

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -80,7 +80,7 @@ async def test_request_url():
         response = JSONResponse(data)
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/123?a=abc")
         assert response.json() == {
             "method": "GET",
@@ -99,7 +99,7 @@ async def test_request_query_params():
         response = JSONResponse({"params": params})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/?a=123&b=456")
         assert response.json() == {"params": {"a": "123", "b": "456"}}
 
@@ -113,7 +113,7 @@ async def test_request_headers():
         response = JSONResponse({"headers": headers})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/", headers={"host": "example.org"})
         assert response.json() == {
             "headers": {
@@ -134,7 +134,7 @@ async def test_request_client():
         )
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.json() == {"host": "127.0.0.1", "port": 123}
 
@@ -147,7 +147,7 @@ async def test_request_body():
         response = JSONResponse({"body": body.decode()})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.json() == {"body": ""}
 
@@ -168,7 +168,7 @@ async def test_request_stream():
         response = JSONResponse({"body": body.decode()})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.json() == {"body": ""}
 
@@ -188,7 +188,7 @@ async def test_request_form_urlencoded():
         await response(scope, receive, send)
         await request.close()
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.post("/", data={"abc": "123 @"})
         assert response.json() == {"form": {"abc": "123 @"}}
 
@@ -210,7 +210,7 @@ async def test_request_multipart_form():
         await response(scope, receive, send)
         await request.close()
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         with tempfile.SpooledTemporaryFile(1024) as file:
             file.write(b"temporary file")
             file.seek(0, 0)
@@ -245,7 +245,7 @@ async def test_request_multipart_form_limit():
     async def app(scope, receive, send):
         await FRequest(scope, receive).form
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         with pytest.raises(RequestEntityTooLarge):
             with tempfile.SpooledTemporaryFile(1024) as file:
                 file.write(b"temporary file")
@@ -274,7 +274,7 @@ async def test_request_body_then_stream():
         response = JSONResponse({"body": body.decode(), "stream": chunks.decode()})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.post("/", content="abc")
         assert response.json() == {"body": "abc", "stream": "abc"}
 
@@ -293,7 +293,7 @@ async def test_request_stream_then_body():
         response = JSONResponse({"body": body.decode(), "stream": chunks.decode()})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.post("/", content="abc")
         assert response.json() == {"body": "<stream consumed>", "stream": "abc"}
 
@@ -306,7 +306,7 @@ async def test_request_json():
         response = JSONResponse({"json": data})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.post("/", json={"a": "123"})
         assert response.json() == {"json": {"a": "123"}}
 
@@ -339,7 +339,7 @@ async def test_request_without_setting_receive():
         response = JSONResponse({"json": data})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.post("/", json={"a": "123"})
         assert response.json() == {"json": "Receive channel not available"}
 
@@ -381,7 +381,7 @@ async def test_request_is_disconnected():
         await response(scope, receive, send)
         disconnected_after_response = await request.is_disconnected()
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.json() == {"disconnected": False}
         assert disconnected_after_response
@@ -400,7 +400,7 @@ async def test_request_cookies():
 
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.text == "Hello, world!"
         response = await client.get("/")
@@ -435,7 +435,7 @@ async def test_cookie_lenient_parsing():
         response = JSONResponse({"cookies": request.cookies})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/", headers={"cookie": tough_cookie})
         result = response.json()
         assert len(result["cookies"]) == 4
@@ -471,7 +471,7 @@ async def test_cookies_edge_cases(set_cookie, expected):
         response = JSONResponse({"cookies": request.cookies})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/", headers={"cookie": set_cookie})
         result = response.json()
         assert result["cookies"] == expected
@@ -512,7 +512,7 @@ async def test_cookies_invalid(set_cookie, expected):
         response = JSONResponse({"cookies": request.cookies})
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/", headers={"cookie": set_cookie})
         result = response.json()
         assert result["cookies"] == expected
@@ -531,7 +531,7 @@ async def test_response_headers():
         response.headers["x-header-2"] = "789"
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.headers["x-header-1"] == "123"
         assert response.headers["x-header-2"] == "789"
@@ -552,7 +552,7 @@ async def test_set_cookie():
         samesite="none",
     )
 
-    async with httpx.AsyncClient(app=response, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(response)) as client:
         response = await client.get("/")
         assert response.text == "Hello, world!"
 
@@ -568,7 +568,7 @@ async def test_delete_cookie():
             response.set_cookie("mycookie", "myvalue")
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.cookies["mycookie"]
         response = await client.get("/")
@@ -584,7 +584,7 @@ async def test_redirect_response():
             response = RedirectResponse("/")
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/redirect", follow_redirects=True)
         assert response.text == "hello, world"
         assert response.url == "http://testserver/"
@@ -597,7 +597,7 @@ async def test_stream_response():
             yield str(i).encode("utf-8")
 
     async with httpx.AsyncClient(
-        app=StreamResponse(generator(10)), base_url="http://testServer/"
+        transport=httpx.ASGITransport(StreamResponse(generator(10))), base_url="http://testServer/"
     ) as client:
         response = await client.get("/")
         assert response.content == b"".join(str(i).encode("utf-8") for i in range(10))
@@ -630,7 +630,7 @@ async def test_file_response(tmp_path: Path, response_class: Type[FileResponse])
     async def app(scope, r, s):
         return await response_class(str(filepath))(scope, r, s)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         response = await client.get("/")
         assert response.status_code == 200
         assert response.headers["content-length"] == str(len(README.encode("utf8")))
@@ -704,7 +704,7 @@ async def test_file_response_with_download_name(tmp_path: Path):
     filepath.write_bytes(README.encode("utf8"))
     file_response = FileResponse(str(filepath), download_name="README.txt")
     async with httpx.AsyncClient(
-        app=file_response, base_url="http://testServer/"
+        transport=httpx.ASGITransport(file_response), base_url="http://testServer/"
     ) as client:
         response = await client.get("/")
         assert (
@@ -737,7 +737,7 @@ async def test_send_event_response():
     )
 
     async with httpx.AsyncClient(
-        app=SendEventResponse(send_events(), ping_interval=0.1),
+        transport=httpx.ASGITransport(SendEventResponse(send_events(), ping_interval=0.1)),
         base_url="http://testServer/",
     ) as client:
         async with client.stream("GET", "/") as resp:
@@ -748,11 +748,11 @@ async def test_send_event_response():
             assert events.replace(": ping\n\n", "") == expected_events
 
     async with httpx.AsyncClient(
-        app=SendEventResponse(
+        transport=httpx.ASGITransport(SendEventResponse(
             send_events(),
             headers={"custom-header": "value"},
             ping_interval=0.1,
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         async with client.stream("GET", "/") as resp:
@@ -772,7 +772,7 @@ async def test_send_event_response_raise_exception():
         raise Exception("Something went wrong")
 
     async with httpx.AsyncClient(
-        app=SendEventResponse(send_events(), ping_interval=0.1),
+        transport=httpx.ASGITransport(SendEventResponse(send_events(), ping_interval=0.1)),
         base_url="http://testServer/",
     ) as client:
         with pytest.raises(Exception, match="Something went wrong"):
@@ -797,7 +797,7 @@ async def test_send_event_response_be_killed():
             killed = True
 
     async with httpx.AsyncClient(
-        app=SendEventResponse(send_events(), ping_interval=0.1),
+        transport=httpx.ASGITransport(SendEventResponse(send_events(), ping_interval=0.1)),
         base_url="http://testServer/",
     ) as client:
         async with client.stream("GET", "/") as resp:
@@ -1042,7 +1042,7 @@ async def test_router():
         ("/redirect", redirect),
         ("/{path}", path),
     )
-    async with httpx.AsyncClient(app=router, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(router)) as client:
         assert (await client.get("/")).text == "homepage"
         assert (await client.get("/baize")).json() == {"path": "baize"}
         assert (await client.get("/baize/")).status_code == 404
@@ -1060,10 +1060,10 @@ async def test_subpaths():
         return PlainTextResponse(request["path"])
 
     async with httpx.AsyncClient(
-        app=Subpaths(
+        transport=httpx.ASGITransport(Subpaths(
             ("/frist", root),
             ("/latest", path),
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         assert (await client.get("/")).status_code == 404
@@ -1071,10 +1071,10 @@ async def test_subpaths():
         assert (await client.get("/latest")).text == ""
 
     async with httpx.AsyncClient(
-        app=Subpaths(
+        transport=httpx.ASGITransport(Subpaths(
             ("", path),
             ("/root", root),
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         assert (await client.get("/")).text == "/"
@@ -1084,10 +1084,10 @@ async def test_subpaths():
 @pytest.mark.asyncio
 async def test_hosts():
     async with httpx.AsyncClient(
-        app=Hosts(
+        transport=httpx.ASGITransport(Hosts(
             ("testServer", PlainTextResponse("testServer")),
             (".*", PlainTextResponse("default host")),
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         assert (
@@ -1111,7 +1111,7 @@ async def test_hosts():
     ],
 )
 async def test_files(app):
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         resp = await client.get("/py.typed")
         assert resp.text == ""
 
@@ -1170,7 +1170,7 @@ async def test_pages(tmpdir):
     )
 
     app = Pages(tmpdir)
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         resp = await client.get("/")
         assert resp.status_code == 200
         assert resp.text == "<html><body>index</body></html>"
@@ -1207,7 +1207,7 @@ async def test_pages(tmpdir):
             await client.get("/d")
 
     app = Pages(tmpdir, handle_404=PlainTextResponse("", 404))
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         assert (await client.get("/d")).status_code == 404
 
 
@@ -1222,7 +1222,7 @@ async def test_request_response():
     async def view(request: Request) -> Response:
         return PlainTextResponse(await request.body)
 
-    async with httpx.AsyncClient(app=view, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(view)) as client:
         assert (await client.get("/")).text == ""
         assert (await client.post("/", content="hello")).text == "hello"
 
@@ -1240,7 +1240,7 @@ async def test_websocket_session():
         await websocket.accept()
         await websocket.close()
 
-    async with httpx.AsyncClient(app=view, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(view)) as client:
         assert (await client.get("/")).status_code == 404
 
 
@@ -1259,7 +1259,7 @@ async def test_decorator():
     async def view(request: Request) -> Response:
         return PlainTextResponse(await request.body)
 
-    async with httpx.AsyncClient(app=view, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(view)) as client:
         assert (await client.get("/")).headers["X-Middleware"] == "1"
 
 
@@ -1278,7 +1278,7 @@ async def test_middleware():
     async def view(request: Request) -> Response:
         return PlainTextResponse(await request.body)
 
-    async with httpx.AsyncClient(app=view, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(view)) as client:
         response = await client.post("/", content="x")
         assert response.headers["X-Middleware"] == "1"
         assert response.text == "x"
@@ -1293,7 +1293,7 @@ async def test_next_request():
         response = await NextResponse.from_app(PlainTextResponse(""), request)
         await response(scope, receive, send)
 
-    async with httpx.AsyncClient(app=app, base_url="http://testServer/") as client:
+    async with httpx.AsyncClient(base_url="http://testServer/", transport=httpx.ASGITransport(app)) as client:
         assert (await client.get("/")).status_code == 200
 
     async def read_body(scope, receive, send):
@@ -1303,7 +1303,7 @@ async def test_next_request():
         await response(scope, receive, send)
 
     async with httpx.AsyncClient(
-        app=read_body, base_url="http://testServer/"
+        transport=httpx.ASGITransport(read_body), base_url="http://testServer/"
     ) as client:
         with pytest.raises(RuntimeError):
             await client.post("/", content="hello")

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -144,13 +144,13 @@ def app_read_body(environ, start_response):
 
 
 def test_multipart_request_empty_data(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", data={}, files=FORCE_MULTIPART)
         assert response.json() == {}
 
 
 def test_multipart_request_data(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", data={"some": "data"}, files=FORCE_MULTIPART)
         assert response.json() == {"some": "data"}
 
@@ -160,7 +160,7 @@ def test_multipart_request_files(tmpdir):
     with open(path, "wb") as file:
         file.write(b"<file content>")
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         with open(path, "rb") as f:
             response = client.post("/", files={"test": f})
             assert response.json() == {
@@ -177,7 +177,7 @@ def test_multipart_request_files_with_content_type(tmpdir):
     with open(path, "wb") as file:
         file.write(b"<file content>")
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         with open(path, "rb") as f:
             response = client.post("/", files={"test": ("test.txt", f, "text/plain")})
             assert response.json() == {
@@ -198,7 +198,7 @@ def test_multipart_request_multiple_files(tmpdir):
     with open(path2, "wb") as file:
         file.write(b"<file2 content>")
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         with open(path1, "rb") as f1, open(path2, "rb") as f2:
             response = client.post(
                 "/", files={"test1": f1, "test2": ("test2.txt", f2, "text/plain")}
@@ -226,7 +226,7 @@ def test_multi_items(tmpdir):
     with open(path2, "wb") as file:
         file.write(b"<file2 content>")
 
-    with httpx.Client(app=multi_items_app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(multi_items_app)) as client:
         with open(path1, "rb") as f1, open(path2, "rb") as f2:
             response = client.post(
                 "/",
@@ -251,7 +251,7 @@ def test_multi_items(tmpdir):
 
 
 def test_multipart_request_mixed_files_and_data(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post(
             "/",
             content=(
@@ -288,7 +288,7 @@ def test_multipart_request_mixed_files_and_data(tmpdir):
 
 
 def test_multipart_request_with_charset_for_filename(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post(
             "/",
             content=(
@@ -316,7 +316,7 @@ def test_multipart_request_with_charset_for_filename(tmpdir):
 
 
 def test_multipart_request_without_charset_for_filename(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post(
             "/",
             content=(
@@ -343,7 +343,7 @@ def test_multipart_request_without_charset_for_filename(tmpdir):
 
 
 def test_multipart_request_with_encoded_value(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post(
             "/",
             content=(
@@ -364,13 +364,13 @@ def test_multipart_request_with_encoded_value(tmpdir):
 
 
 def test_urlencoded_request_data(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", data={"some": "data"})
         assert response.json() == {"some": "data"}
 
 
 def test_no_request_data(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post(
             "/", headers={"content-type": "application/x-www-form-urlencoded"}
         )
@@ -378,25 +378,25 @@ def test_no_request_data(tmpdir):
 
 
 def test_urlencoded_percent_encoding(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", data={"some": "da ta"})
         assert response.json() == {"some": "da ta"}
 
 
 def test_urlencoded_percent_encoding_keys(tmpdir):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", data={"so me": "data"})
         assert response.json() == {"so me": "data"}
 
 
 def test_urlencoded_multi_field_app_reads_body(tmpdir):
-    with httpx.Client(app=app_read_body, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app_read_body)) as client:
         response = client.post("/", data={"some": "data", "second": "key pair"})
         assert response.json() == {"some": "data", "second": "key pair"}
 
 
 def test_multipart_multi_field_app_reads_body(tmpdir):
-    with httpx.Client(app=app_read_body, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app_read_body)) as client:
         response = client.post(
             "/", data={"some": "data", "second": "key pair"}, files=FORCE_MULTIPART
         )

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -62,7 +62,7 @@ def test_request_url():
         response = PlainTextResponse(request.method + " " + str(request.url))
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/123?a=abc")
         assert response.text == "GET http://testserver/123?a=abc"
 
@@ -77,7 +77,7 @@ def test_request_query_params():
         response = JSONResponse({"params": params})
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/?a=123&b=456")
         assert response.json() == {"params": {"a": "123", "b": "456"}}
 
@@ -90,7 +90,7 @@ def test_request_headers():
         response = JSONResponse({"headers": headers})
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/", headers={"host": "example.org"})
         assert response.json() == {
             "headers": {
@@ -110,7 +110,7 @@ def test_request_client():
         )
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/")
         assert response.json() == {"host": None, "port": None}
 
@@ -125,7 +125,7 @@ def test_request_body():
         response = JSONResponse({"body": body.decode()})
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/")
         assert response.json() == {"body": ""}
 
@@ -145,7 +145,7 @@ def test_request_stream():
         response = PlainTextResponse(body)
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/")
         assert response.text == ""
 
@@ -164,7 +164,7 @@ def test_request_form_urlencoded():
         return response(environ, start_response)
         request.close()
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", data={"abc": "123 @"})
         assert response.json() == {"form": {"abc": "123 @"}}
 
@@ -185,7 +185,7 @@ def test_request_multipart_form():
         request.close()
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         with tempfile.SpooledTemporaryFile(1024) as file:
             file.write(b"temporary file")
             file.seek(0, 0)
@@ -217,7 +217,7 @@ def test_request_multipart_form_limit():
     def app(environ, start_response):
         FRequest(environ).form
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         with pytest.raises(RequestEntityTooLarge):
             with tempfile.SpooledTemporaryFile(1024) as file:
                 file.write(b"temporary file")
@@ -243,7 +243,7 @@ def test_request_body_then_stream():
         response = JSONResponse({"body": body.decode(), "stream": chunks.decode()})
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", content="abc")
         assert response.json() == {"body": "abc", "stream": "abc"}
 
@@ -261,7 +261,7 @@ def test_request_stream_then_body():
         response = JSONResponse({"body": body.decode(), "stream": chunks.decode()})
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", content="abc")
         assert response.json() == {"body": "<stream consumed>", "stream": "abc"}
 
@@ -273,7 +273,7 @@ def test_request_json():
         response = JSONResponse({"json": data})
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.post("/", json={"a": "123"})
         assert response.json() == {"json": {"a": "123"}}
 
@@ -301,7 +301,7 @@ def test_request_accpet():
             response = PlainTextResponse(data)
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/", headers={"Accept": "application/json"})
         assert response.json() == {"data": data}
 
@@ -312,7 +312,7 @@ def test_request_accpet():
 
 
 def test_unknown_status():
-    with httpx.Client(app=Response(600), base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(Response(600))) as client:
         response = client.get("/")
         assert response.status_code == 600
 
@@ -325,7 +325,7 @@ def test_redirect_response():
             response = RedirectResponse("/")
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/redirect", follow_redirects=True)
         assert response.text == "hello, world"
         assert response.url == "http://testserver/"
@@ -337,7 +337,7 @@ def test_stream_response():
             yield str(i).encode("utf-8")
 
     with httpx.Client(
-        app=StreamResponse(generator(10)), base_url="http://testServer/"
+        transport=httpx.WSGITransport(StreamResponse(generator(10))), base_url="http://testServer/"
     ) as client:
         response = client.get("/")
         assert response.content == b"".join(str(i).encode("utf-8") for i in range(10))
@@ -358,7 +358,7 @@ def test_file_response(tmp_path: Path):
     filepath = tmp_path / "README.txt"
     filepath.write_bytes(README.encode("utf8"))
     file_response = FileResponse(str(filepath))
-    with httpx.Client(app=file_response, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(file_response)) as client:
         response = client.get("/")
         assert response.status_code == 200
         assert response.headers["content-length"] == str(len(README.encode("utf8")))
@@ -427,7 +427,7 @@ def test_file_response_with_download_name(tmp_path: Path):
     filepath = tmp_path / "README"
     filepath.write_bytes(README.encode("utf8"))
     file_response = FileResponse(str(filepath), download_name="README.txt")
-    with httpx.Client(app=file_response, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(file_response)) as client:
         response = client.get("/")
         assert (
             response.headers["content-disposition"]
@@ -458,7 +458,7 @@ def test_send_event_response():
     )
 
     with httpx.Client(
-        app=SendEventResponse(send_events(), ping_interval=0.1),
+        transport=httpx.WSGITransport(SendEventResponse(send_events(), ping_interval=0.1)),
         base_url="http://testServer/",
     ) as client:
         with client.stream("GET", "/") as resp:
@@ -469,11 +469,11 @@ def test_send_event_response():
             assert events.replace(": ping\n\n", "") == expected_events
 
     with httpx.Client(
-        app=SendEventResponse(
+        transport=httpx.WSGITransport(SendEventResponse(
             send_events(),
             headers={"custom-header": "value"},
             ping_interval=0.1,
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         with client.stream("GET", "/") as resp:
@@ -492,7 +492,7 @@ def test_send_event_response_raise_exception():
         raise Exception("Something went wrong")
 
     with httpx.Client(
-        app=SendEventResponse(send_events(), ping_interval=0.1),
+        transport=httpx.WSGITransport(SendEventResponse(send_events(), ping_interval=0.1)),
         base_url="http://testServer/",
     ) as client:
         with client.stream("GET", "/") as resp:
@@ -516,7 +516,7 @@ def test_send_event_response_be_killed():
             killed = True
 
     with httpx.Client(
-        app=SendEventResponse(send_events(), ping_interval=0.1),
+        transport=httpx.WSGITransport(SendEventResponse(send_events(), ping_interval=0.1)),
         base_url="http://testServer/",
     ) as client:
         with client.stream("GET", "/") as resp:
@@ -561,7 +561,7 @@ def test_router():
         ("/redirect", redirect),
         ("/{path}", path),
     )
-    with httpx.Client(app=router, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(router)) as client:
         assert client.get("/").text == "homepage"
         assert client.get("/baize").json() == {"path": "baize"}
         assert client.get("/baize/").status_code == 404
@@ -578,10 +578,10 @@ def test_subpaths():
         return PlainTextResponse(request.get("PATH_INFO", ""))
 
     with httpx.Client(
-        app=Subpaths(
+        transport=httpx.WSGITransport(Subpaths(
             ("/frist", root),
             ("/latest", path),
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         assert client.get("/").status_code == 404
@@ -589,10 +589,10 @@ def test_subpaths():
         assert client.get("/latest").text == ""
 
     with httpx.Client(
-        app=Subpaths(
+        transport=httpx.WSGITransport(Subpaths(
             ("", path),
             ("/root", root),
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         assert client.get("/").text == "/"
@@ -601,10 +601,10 @@ def test_subpaths():
 
 def test_hosts():
     with httpx.Client(
-        app=Hosts(
+        transport=httpx.WSGITransport(Hosts(
             ("testServer", PlainTextResponse("testServer")),
             (".*", PlainTextResponse("default host")),
-        ),
+        )),
         base_url="http://testServer/",
     ) as client:
         assert client.get("/", headers={"host": "testServer"}).text == "testServer"
@@ -621,7 +621,7 @@ def test_hosts():
     ],
 )
 def test_files(app):
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         resp = client.get("/py.typed")
         assert resp.text == ""
 
@@ -677,7 +677,7 @@ def test_pages(tmpdir):
     )
 
     app = Pages(tmpdir)
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         resp = client.get("/")
         assert resp.status_code == 200
         assert resp.text == "<html><body>index</body></html>"
@@ -714,7 +714,7 @@ def test_pages(tmpdir):
             client.get("/d")
 
     app = Pages(tmpdir, handle_404=PlainTextResponse("", 404))
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         assert client.get("/d").status_code == 404
 
 
@@ -728,7 +728,7 @@ def test_request_response():
     def view(request: Request) -> Response:
         return PlainTextResponse(request.body)
 
-    with httpx.Client(app=view, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(view)) as client:
         assert client.get("/").text == ""
         assert client.post("/", content="hello").text == "hello"
 
@@ -747,7 +747,7 @@ def test_decorator():
     def view(request: Request) -> Response:
         return PlainTextResponse(request.body)
 
-    with httpx.Client(app=view, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(view)) as client:
         assert client.get("/").headers["X-Middleware"] == "1"
 
 
@@ -765,7 +765,7 @@ def test_middleware():
     def view(request: Request) -> Response:
         return PlainTextResponse(request.body)
 
-    with httpx.Client(app=view, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(view)) as client:
         assert client.get("/").headers["X-Middleware"] == "1"
 
 
@@ -777,7 +777,7 @@ def test_next_request():
         response = NextResponse.from_app(PlainTextResponse(""), request)
         return response(environ, start_response)
 
-    with httpx.Client(app=app, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(app)) as client:
         response = client.get("/")
         assert response.status_code == 200
 
@@ -787,6 +787,6 @@ def test_next_request():
         response = NextResponse.from_app(PlainTextResponse(""), request)
         return response(environ, start_response)
 
-    with httpx.Client(app=read_body, base_url="http://testServer/") as client:
+    with httpx.Client(base_url="http://testServer/", transport=httpx.WSGITransport(read_body)) as client:
         with pytest.raises(RuntimeError):
             client.post("/", content="hello")

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import time
 from inspect import cleandoc
@@ -130,7 +131,8 @@ def test_request_body():
         assert response.json() == {"body": ""}
 
         response = client.post("/", json={"a": "123"})
-        assert response.json() == {"body": '{"a": "123"}'}
+        inner_json = json.loads(response.json()["body"])
+        assert inner_json == {"a": "123"}
 
         response = client.post("/", content="abc")
         assert response.json() == {"body": "abc"}
@@ -150,7 +152,7 @@ def test_request_stream():
         assert response.text == ""
 
         response = client.post("/", json={"a": "123"})
-        assert response.text == '{"a": "123"}'
+        assert response.json() == {"a": "123"}
 
         response = client.post("/", content="abc")
         assert response.text == "abc"


### PR DESCRIPTION
As stated in #73  `httpx>=0.28` breaks some tests due to deprecated `app` keyword argument in `Client` and `AsyncClient`. This applies suggested fix from the issue, i.e.: remove `app=app` and use `transport=WSGITransport(app)` for `Client` and `ASGITransport` for `AsyncClient`.

The second commit fixes assertions failing due to comparison of identical JSONs but represented as strings.